### PR TITLE
Rename the challenge lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,9 +11,9 @@ provider:
   stage: ${opt:stage}
 
 functions:
-  hello:
+  challenge:
     handler: src/challenge-handler/handler.handleChallengeEvent
     events:
       - http:
-          path: hello
+          path: ''
           method: get


### PR DESCRIPTION
The challenge lambda and it's API gateway path are currently named "hello" as a hangover from being created by the serverless framework. This renames the lambda to "challenge", and also renames the API gateway path to an empty string