### PR TITLE
Add SNS topics to serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,14 @@ functions:
           method: post
     environment:
       ALMA_SECRET_KEY_NAME: /library-api-gateway/webhook-handler/shared-secret
+      LoanCreatedTopicArn: ${self:custom.topicArns.loanCreated}
+      LoanDueDateTopicArn: ${self:custom.topicArns.loanDueDate}
+      LoanRenewedTopicArn: ${self:custom.topicArns.loanRenewed}
+      LoanReturnedTopicArn: ${self:custom.topicArns.loanReturned}
+      RequestCreatedTopicArn:  ${self:custom.topicArns.requestCreated}
+      RequestClosedTopicArn: ${self:custom.topicArns.requestClosed}
+      RequestCanceledTopicArn: ${self:custom.topicArns.requestCanceled}
+      RequestPlacedOnShelfTopicArn: ${self:custom.topicArns.requestPlacedOnShelf}
     role: webhookHandlerRole
     tags:
       serverless: true

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,6 +71,79 @@ resources:
                   - kms:Encrypt
                   - kms:Decrypt
                 Resource: ${self:custom.KeyArns.${opt:stage}}
+    loanCreatedTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaLoanCreated
+    loanDueDateTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaLoanDueDate
+    loanRenewedTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaLoanRenewed
+    loanReturnedTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaLoanReturned
+    requestCreatedTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaRequestCreated
+    requestClosedTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaRequestClosed
+    requestCanceledTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaRequestCanceled
+    requestPlacedOnShelfTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaRequestPlacedOnShelf
+  Outputs:
+    LoanCreatedTopicArn:
+      Description: Arn for Loan Created Topic
+      Value: ${self:custom.topicArns.loanCreated}
+      Export:
+        Name: ${self:service}:${opt:stage}:LoanCreatedTopicArn
+    LoanDueDateTopicArn:
+      Description: Arn for Loan Due Date Topic
+      Value: ${self:custom.topicArns.loanDueDate}
+      Export:
+        Name: ${self:service}:${opt:stage}:LoanDueDateTopicArn
+    LoanRenewedTopicArn:
+      Description: Arn for Loan Renewed Topic
+      Value: ${self:custom.topicArns.loanRenewed}
+      Export:
+        Name: ${self:service}:${opt:stage}:LoanRenewedTopicArn
+    LoanReturnedTopicArn:
+      Description: Arn for Loan Returned Topic
+      Value: ${self:custom.topicArns.loanReturned}
+      Export:
+        Name: ${self:service}:${opt:stage}:LoanReturnedTopicArn
+    RequestCreatedTopicArn:
+      Description: Arn for Request Created Topic
+      Value: ${self:custom.topicArns.requestCreated}
+      Export:
+        Name: ${self:service}:${opt:stage}:RequestCreatedTopicArn
+    RequestClosedTopicArn:
+      Description: Arn for Request Closed Topic
+      Value: ${self:custom.topicArns.requestClosed}
+      Export:
+        Name: ${self:service}:${opt:stage}:RequestClosedTopicArn
+    RequestCanceledTopicArn:
+      Description: Arn for Request Canceled Topic
+      Value: ${self:custom.topicArns.requestCanceled}
+      Export:
+        Name: ${self:service}:${opt:stage}:RequestCanceledTopicArn
+    RequestPlacedOnShelfTopicArn:
+      Description: Arn for Request Placed On Shelf Topic
+      Value: ${self:custom.topicArns.requestPlacedOnShelf}
+      Export:
+        Name: ${self:service}:${opt:stage}:RequestPlacedOnShelfTopicArn
 
 custom:
   KeyArns:
@@ -81,6 +154,63 @@ custom:
     dev: development
     stg: staging
     prod: production
+  topicArns:
+    loanCreated:
+      "Fn::Join": 
+          - ":"
+          - - "arn:aws:sns"
+            - Ref: "AWS::Region"
+            - Ref: "AWS::AccountId"
+            - "Fn::GetAtt": [loanCreatedTopic, TopicName]
+    loanDueDate:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [loanDueDateTopic, TopicName]
+    loanRenewed:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [loanRenewedTopic, TopicName]
+    loanReturned:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [loanReturnedTopic, TopicName]
+    requestCreated:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [requestCreatedTopic, TopicName]
+    requestClosed:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [requestClosedTopic, TopicName]
+    requestCanceled:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [requestCanceledTopic, TopicName]
+    requestPlacedOnShelf:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [requestPlacedOnShelfTopic, TopicName]
 
 plugins:
   - serverless-pseudo-parameters


### PR DESCRIPTION
The webhook handler requires there to exist SNS topics for it to be able to publish events to.

This updates the serverless.yml file to create SNS topics for each of the webhook events, and exports the ARNs of these topics from the CloudFormation stack.