### PR TITLE
Fix returned error for unsupported events

### DIFF
--- a/src/webhook-handler/handler.js
+++ b/src/webhook-handler/handler.js
@@ -36,7 +36,6 @@ module.exports.handleWebhookEvent = (event, context, callback) => {
 
 const handleSnsPublish = (event) => {
   const body = extractMessageBody(event)
-  // const eventTopicArn = eventTopicData.get(body.event.value).sns_arn
   const eventTopicArn = lookupTopicArn(body.event.value)
   const eventTopic = new Topic(eventTopicArn, process.env.AWS_DEFAULT_REGION)
 

--- a/src/webhook-handler/handler.js
+++ b/src/webhook-handler/handler.js
@@ -36,10 +36,19 @@ module.exports.handleWebhookEvent = (event, context, callback) => {
 
 const handleSnsPublish = (event) => {
   const body = extractMessageBody(event)
-  const eventTopicArn = eventTopicData.get(body.event.value).sns_arn
+  // const eventTopicArn = eventTopicData.get(body.event.value).sns_arn
+  const eventTopicArn = lookupTopicArn(body.event.value)
   const eventTopic = new Topic(eventTopicArn, process.env.AWS_DEFAULT_REGION)
 
   return eventTopic.publish(event.body)
+}
+
+const lookupTopicArn = (eventType) => {
+  try {
+    return eventTopicData.get(eventType).sns_arn
+  } catch (e) {
+    throw new HTTPError(422, `Event type ${eventType} is not supported`)
+  }
 }
 
 const extractMessageBody = (event) => {

--- a/test/webhook-handler/webhook-handler-test.js
+++ b/test/webhook-handler/webhook-handler-test.js
@@ -66,10 +66,10 @@ describe('webhook handler tests', () => {
       })
     })
 
-    it('should callback with a 500 response if the event type is not supported', (done) => {
+    it('should callback with a 422 response if the event type is not supported', (done) => {
       handler.handleWebhookEvent(invalidEventType, null, (err, res) => {
         should.not.exist(err)
-        res.statusCode.should.equal(500)
+        res.statusCode.should.equal(422)
         done()
       })
     })

--- a/test/webhook-handler/webhook-handler-test.js
+++ b/test/webhook-handler/webhook-handler-test.js
@@ -133,6 +133,16 @@ describe('webhook handler tests', () => {
       AWS_MOCK.restore('SNS')
     })
 
+    it('should return a 500 error if Topic publish is rejected', () => {
+      let publishStub = sandbox.stub(Topic.prototype, 'publish')
+      publishStub.rejects(new Error('publish failed'))
+
+      handler.handleWebhookEvent(loanCreatedEvent, null, (err, res) => {
+        should.not.exist(err)
+        res.statusCode.should.equal(500)
+      })
+    })
+
     eventTopicData.forEach((data, topicName) => {
       let topicArn = `arn:${topicName.toLowerCase()}`
       it(`should call SNS publish with the event body & correct topic arn ${topicArn}`, (done) => {


### PR DESCRIPTION
Alma will retry webhook requests if it receives a 500 response, however for unsupported events we do not want the request to be retried. 

This changes the webhook handler to return a 422 (Unprocessable entity) error when an unsupported event type is sent by Alma.