### PR TITLE
Request hold shelf topic

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,7 @@ provider:
         - ${self:custom.topicArns.requestCreated}
         - ${self:custom.topicArns.requestClosed}
         - ${self:custom.topicArns.requestCanceled}
+        - ${self:custom.topicArns.requestPlacedOnShelf}
 
 functions:
   challenge:
@@ -49,6 +50,7 @@ functions:
       RequestCreatedTopicArn:  ${self:custom.topicArns.requestCreated}
       RequestClosedTopicArn: ${self:custom.topicArns.requestClosed}
       RequestCanceledTopicArn: ${self:custom.topicArns.requestCanceled}
+      RequestPlacedOnShelfTopicArn: ${self:custom.topicArns.requestPlacedOnShelf}
     role: webhookHandlerRole
     tags:
       serverless: true
@@ -118,6 +120,10 @@ resources:
       Type: AWS::SNS::Topic
       Properties:
         DisplayName: AlmaRequestCanceled
+    requestPlacedOnShelfTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: AlmaRequestPlacedOnShelf
   Outputs:
     LoanCreatedTopicArn:
       Description: Arn for Loan Created Topic
@@ -154,6 +160,11 @@ resources:
       Value: ${self:custom.topicArns.requestCanceled}
       Export:
         Name: ${self:service}:${opt:stage}:RequestCanceledTopicArn
+    RequestPlacedOnShelfTopicArn:
+      Description: Arn for Request Placed On Shelf Topic
+      Value: ${self:custom.topicArns.requestPlacedOnShelf}
+      Export:
+        Name: ${self:service}:${opt:stage}:RequestPlacedOnShelfTopicArn
 
 custom:
   KeyArns:
@@ -214,6 +225,13 @@ custom:
           - Ref: "AWS::Region"
           - Ref: "AWS::AccountId"
           - "Fn::GetAtt": [requestCanceledTopic, TopicName]
+    requestPlacedOnShelf:
+      "Fn::Join": 
+        - ":"
+        - - "arn:aws:sns"
+          - Ref: "AWS::Region"
+          - Ref: "AWS::AccountId"
+          - "Fn::GetAtt": [requestPlacedOnShelfTopic, TopicName]
 
 plugins:
   - serverless-pseudo-parameters

--- a/src/webhook-handler/eventTopicData.js
+++ b/src/webhook-handler/eventTopicData.js
@@ -33,6 +33,11 @@ const eventTopicData = new Map([
     {
       sns_arn: process.env.RequestCanceledTopicArn
     }
+  ],
+  ['REQUEST_PLACED_ON_SHELF',
+    {
+      sns_arn: process.env.RequestPlacedOnShelfTopicArn
+    }
   ]
 ])
 

--- a/test/webhook-handler/event-topic-data-test.js
+++ b/test/webhook-handler/event-topic-data-test.js
@@ -14,6 +14,7 @@ process.env.LoanReturnedTopicArn = 'loan returned topic'
 process.env.RequestCreatedTopicArn = 'request created topic'
 process.env.RequestClosedTopicArn = 'request closed topic'
 process.env.RequestCanceledTopicArn = 'request canceled topic'
+process.env.RequestPlacedOnShelfTopicArn = 'request placed on shelf topic'
 
 // Module under test
 const eventTopicData = require('../../src/webhook-handler/eventTopicData')
@@ -66,6 +67,12 @@ describe('event topic data tests', () => {
   it('should return the request canceled ARN environment variable', () => {
     eventTopicData.get('REQUEST_CANCELED').should.deep.equal({
       sns_arn: 'request canceled topic'
+    })
+  })
+
+  it('should return the request placed on shelf ARN environment variable', () => {
+    eventTopicData.get('REQUEST_PLACED_ON_SHELF').should.deep.equal({
+      sns_arn: 'request placed on shelf topic'
     })
   })
 })

--- a/test/webhook-handler/events/request_placed_on_shelf_event.json
+++ b/test/webhook-handler/events/request_placed_on_shelf_event.json
@@ -1,0 +1,58 @@
+{
+  "body": "{\"representation\":null,\"portfolio\":null,\"item\":null,\"id\":\"1234567890101112\",\"action\":\"REQUEST\",\"institution\":{\"desc\":\"Lancaster University\",\"value\":\"44LAN_INST\"},\"time\":\"2018-02-23T11:10:12.005Z\",\"event\":{\"desc\":\"Request plaeed on shelf\",\"value\":\"REQUEST_PLACED_ON_SHELF\"},\"user_request\":{\"title\":\"Test title\",\"author\":null,\"description\":null,\"comment\":null,\"request_id\":\"83013520000121\",\"request_type\":\"HOLD\",\"pickup_location\":\"Burns\",\"pickup_location_type\":\"LIBRARY\",\"pickup_location_library\":\"BURNS\",\"material_type\":{\"value\":\"BK\",\"desc\":\"Book\"},\"request_status\":\"NOT_STARTED\",\"place_in_queue\":1,\"request_date\":\"2013-11-12Z\"},\"holding\":null}",
+  "resource": "/{proxy+}",
+  "requestContext": {
+    "resourceId": "123456",
+    "apiId": "1234567890",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "accountId": "123456789012",
+    "identity": {
+      "apiKey": null,
+      "userArn": null,
+      "cognitoAuthenticationType": null,
+      "caller": null,
+      "userAgent": "Custom User Agent String",
+      "user": null,
+      "cognitoIdentityPoolId": null,
+      "cognitoIdentityId": null,
+      "cognitoAuthenticationProvider": null,
+      "sourceIp": "127.0.0.1",
+      "accountId": null
+    },
+    "stage": "prod"
+  },
+  "queryStringParameters": {
+  },
+  "headers": {
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "Accept-Language": "en-US,en;q=0.8",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "CloudFront-Viewer-Country": "US",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Upgrade-Insecure-Requests": "1",
+    "X-Forwarded-Port": "443",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "X-Forwarded-Proto": "https",
+    "X-Amz-Cf-Id": "aaaaaaaaaae3VYQb9jd-nvCd-de396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "Cache-Control": "max-age=0",
+    "User-Agent": "Custom User Agent String",
+    "CloudFront-Forwarded-Proto": "https",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "X-Exl-Signature": "JtY3FdVta7wSOdOiCmtBky2jSGCDgHLqH0/4F/VZjvM=",
+    "Content-type": "application/json"
+  },
+  "pathParameters": {
+    "proxy": "/examplepath"
+  },
+  "httpMethod": "POST",
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "path": "/examplepath"
+}


### PR DESCRIPTION
This handles webhook events from alma with type REQUEST_PLACED_ON_SHELF.

This creates an SNS topic for these events, and updates the lambda to publish the data for these events to this SNS topic when the webhook events are received.

A test request placed on shelf event is included as request_closed_event.json, this is based off the webhook specification from ExLibris