### PR TITLE
Deployment Fixes

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,6 +22,13 @@ provider:
         - ${self:custom.topicArns.requestClosed}
         - ${self:custom.topicArns.requestCanceled}
         - ${self:custom.topicArns.requestPlacedOnShelf}
+    - Effect: Allow
+      Action: 
+        - ssm:GetParameter
+        - ssm:GetParameters
+        - ssm:GetParametersByPath
+      Resource:
+        - ${env:ALMA_SHARED_SECRET_ARN}
 
 functions:
   challenge:
@@ -42,7 +49,7 @@ functions:
           path: ''
           method: post
     environment:
-      ALMA_SECRET_KEY_NAME: /library-api-gateway/webhook-handler/shared-secret
+      ALMA_SECRET_KEY_NAME: ${env:ALMA_SHARED_SECRET_NAME}
       LoanCreatedTopicArn: ${self:custom.topicArns.loanCreated}
       LoanDueDateTopicArn: ${self:custom.topicArns.loanDueDate}
       LoanRenewedTopicArn: ${self:custom.topicArns.loanRenewed}
@@ -51,7 +58,6 @@ functions:
       RequestClosedTopicArn: ${self:custom.topicArns.requestClosed}
       RequestCanceledTopicArn: ${self:custom.topicArns.requestCanceled}
       RequestPlacedOnShelfTopicArn: ${self:custom.topicArns.requestPlacedOnShelf}
-    role: webhookHandlerRole
     tags:
       serverless: true
       environment: ${self:custom.environmentNames.${opt:stage}}
@@ -60,38 +66,6 @@ functions:
 
 resources:
   Resources:
-    webhookHandlerRole:
-      Type: AWS::IAM::Role
-      Properties:
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service:
-                  - lambda.amazonaws.com
-              Action: sts:AssumeRole
-        Policies:
-          - PolicyName: ${self:service}-${opt:stage}-AllowGetSSMParameters-Policy
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                Effect: Allow
-                Action: 
-                  - ssm:GetParameter
-                  - ssm:GetParameters
-                  - ssm:GetParametersByPath
-                Resource: arn:aws:ssm:eu-west-2:#{AWS::AccountId}:parameter/library-api-gateway/webhook-handler/*
-          - PolicyName: ${self:service}-${opt:stage}-AllowKMSKeyAccess-Policy
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                Effect: Allow
-                Action:
-                  - kms:GenerateDataKey
-                  - kms:Encrypt
-                  - kms:Decrypt
-                Resource: ${self:custom.KeyArns.${opt:stage}}
     loanCreatedTopic:
       Type: AWS::SNS::Topic
       Properties:

--- a/src/webhook-handler/handler.js
+++ b/src/webhook-handler/handler.js
@@ -20,6 +20,7 @@ module.exports.handleWebhookEvent = (event, context, callback) => {
       }
     })
     .catch((e) => {
+      console.log(e)
       if (e instanceof HTTPError) {
         response = errorResponse(e.status, e.message)
       } else {

--- a/src/webhook-handler/request-validator.js
+++ b/src/webhook-handler/request-validator.js
@@ -31,7 +31,7 @@ const getSecretFromAWS = () => {
 
   return new Promise((resolve, reject) => {
     ssm.getParameter(params, (err, data) => {
-      err ? reject(err) : resolve(data.Value)
+      err ? reject(err) : resolve(data.Parameter.Value)
     })
   })
 }

--- a/test/webhook-handler/validation-test.js
+++ b/test/webhook-handler/validation-test.js
@@ -28,14 +28,14 @@ describe('signature validation tests', () => {
   })
 
   it('should throw an error if the signature is invalid', () => {
-    AWS_MOCK.mock('SSM', 'getParameter', { Value: 'secretkey' })
+    AWS_MOCK.mock('SSM', 'getParameter', { Parameter: { Value: 'secretkey' } })
 
     validateRequestSignature('a message', 'not a valid signature').should.eventually.be.rejectedWith('An invalid message signature was sent')
       .and.should.eventually.be.an.instanceof(HTTPError)
   })
 
   it('should not throw an error if the signature is valid', () => {
-    AWS_MOCK.mock('SSM', 'getParameter', { Value: 'secretkey' })
+    AWS_MOCK.mock('SSM', 'getParameter', { Parameter: { Value: 'secretkey' } })
 
     return validateRequestSignature("{'api':'alma'}", 'FPkZ/un59vBhgs4dn6yqhqMosD4oK4/fp8swRtkVxAE=')
       .should.eventually.be.fulfilled

--- a/test/webhook-handler/webhook-handler-test.js
+++ b/test/webhook-handler/webhook-handler-test.js
@@ -30,7 +30,7 @@ describe('webhook handler tests', () => {
 
   describe('validation tests', () => {
     before(() => {
-      AWS_MOCK.mock('SSM', 'getParameter', { Value: 'secretkey' })
+      AWS_MOCK.mock('SSM', 'getParameter', { Parameter: { Value: 'secretkey' } })
       process.env.ALMA_SECRET_KEY_NAME = 'testkey'
     })
 
@@ -77,7 +77,7 @@ describe('webhook handler tests', () => {
 
   describe('Topic publish tests', () => {
     before(() => {
-      AWS_MOCK.mock('SSM', 'getParameter', { Value: 'secretkey' })
+      AWS_MOCK.mock('SSM', 'getParameter', { Parameter: { Value: 'secretkey' } })
       process.env.ALMA_SECRET_KEY_NAME = 'testkey'
       process.env.AWS_DEFAULT_REGION = 'eu-west-2'
     })
@@ -118,7 +118,7 @@ describe('webhook handler tests', () => {
 
   describe('End to end tests', () => {
     before(() => {
-      AWS_MOCK.mock('SSM', 'getParameter', { Value: 'secretkey' })
+      AWS_MOCK.mock('SSM', 'getParameter', { Parameter: { Value: 'secretkey' } })
       process.env.ALMA_SECRET_KEY_NAME = 'testkey'
       process.env.AWS_DEFAULT_REGION = 'eu-west-2'
     })


### PR DESCRIPTION
This fixes some IAM permissions errors in `serverless.yml` that were preventing proper deployment, and an issue with retrieving the shared secret from SSM not correctly getting the parameter from the response.