### PR TITLE
Dynamic SSM Parameter ARN

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ provider:
         - ssm:GetParameters
         - ssm:GetParametersByPath
       Resource:
-        - ${env:ALMA_SHARED_SECRET_ARN}
+        - arn:aws:ssm:#{AWS::Region}:#{AWS:AccountID}:parameter/${env:ALMA_SHARED_SECRET_NAME}
 
 functions:
   challenge:


### PR DESCRIPTION
This changes the ARN of the Alma shared secret SSM parameter to be generated dynamically in `serverless.yml`, based on the AWS Region & Account ID, and the shared secret name.