### PR TITLE
Fix SSM Parameter ARN

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ provider:
         - ssm:GetParameters
         - ssm:GetParametersByPath
       Resource:
-        - arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter/${env:ALMA_SHARED_SECRET_NAME}
+        - arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter${env:ALMA_SHARED_SECRET_NAME}
 
 functions:
   challenge:


### PR DESCRIPTION
This fixes an issue with the SSM parameter ARN, where a slash `/` was included both in the ARN template and the parameter name, resulting in an incorrect ARN.